### PR TITLE
Round to supported rate before setting temp basal rate

### DIFF
--- a/MinimedKit/PumpManager/MinimedPumpManager.swift
+++ b/MinimedKit/PumpManager/MinimedPumpManager.swift
@@ -941,6 +941,10 @@ extension MinimedPumpManager: PumpManager {
         return state.pumpModel.supportedBasalRates
     }
 
+    public func roundToSupportedBasalRate(unitsPerHour: Double) -> Double {
+        return supportedBasalRates.last(where: { $0 <= unitsPerHour }) ?? 0
+    }
+
     public var supportedBolusVolumes: [Double] {
         return state.pumpModel.supportedBolusVolumes
     }
@@ -1321,13 +1325,16 @@ extension MinimedPumpManager: PumpManager {
             
             self.recents.tempBasalEngageState = .engaging
 
-            let result = session.setTempBasal(unitsPerHour, duration: duration)
-            
+            // Round to nearest supported rate
+            let rate = self.roundToSupportedBasalRate(unitsPerHour: unitsPerHour)
+
+            let result = session.setTempBasal(rate, duration: duration)
+
             switch result {
             case .success:
                 let now = self.dateGenerator()
 
-                let dose = UnfinalizedDose(tempBasalRate: unitsPerHour, startTime: now, duration: duration, insulinType: insulinType, automatic: true)
+                let dose = UnfinalizedDose(tempBasalRate: rate, startTime: now, duration: duration, insulinType: insulinType, automatic: true)
                 
                 self.recents.tempBasalEngageState = .stable
                 


### PR DESCRIPTION
This PR mirrors https://github.com/LoopKit/MinimedKit/pull/16

The issue this addresses would not be noticed with Loop, as Loop rounds before attempting to enact a temporary basal rate. This issue became apparent when using Trio, though, since Trio does not round before attempting to enact a temporary basal rate, leaving the task of rounding up to the pump's submodule. OmniBLE and OmniKit both already internally handle this rounding task, so this PR aims to add it to MinimedKit as well.

I added this commit to my in-vitro build of Trio-dev.

I added a debugging log message in Trio whenever it attempts to enact a temp basal rate that is unsupported by the pump. Before when this was triggered, I would check Trio's History and see two temp basal records for the same time and one of them would be for the unsupported rate. Here's an example of that:

<img width=350px src=https://github.com/user-attachments/assets/20266603-ea14-455b-906a-b48c38e71a43>

Since adding this commit to my in-vitro Trio build, however, I have had a couple log messages for attempts to enact an unsupported basal rate, but Trio's History only shows the single rounded and supported temp basal rate. Given this, I think this commit solves this issue.